### PR TITLE
update slide link (meeting at August 18, 2023)

### DIFF
--- a/2023/08-18.md
+++ b/2023/08-18.md
@@ -15,7 +15,7 @@
 * [Minutes](https://docs.google.com/document/d/1GP3qSSSqwl_HZIQCG0LUPCw1iwTJoobdWX2UmNWyx-o/edit?usp=sharing)
 * [Chair Slides](https://docs.google.com/presentation/d/1csM5QcC8uqreUncjYS0lCDGmr4S7By-KvlcNRha8jKI/edit?usp=sharing)
 * [Storage Partitioning](https://docs.google.com/presentation/d/1XRJ-5V6Rq9XybIa03NWtqps1y50d8Vf_TG4lpWWpCY4/edit?usp=sharing)
-* [Privacy-Enhanced Revocation Slides](https://drive.google.com/file/d/1RYe22ZPdPvAAM5unby6wJH3aYi43Ewm9/view?usp=drive_link)
+* [Privacy-Enhanced Revocation Slides](https://speakerdeck.com/akakou/privacy-enhanced-revocation-and-view-of-applying-to-web)
   
 
 ## Minutes
@@ -24,7 +24,7 @@ Michael: We do anti-abuse and anti-automation. All of our collection is first pa
 
 Steven: Please let people in the ecosystem to know about the storage partitioning change. 
 
-Kosei presents their slides (https://drive.google.com/file/d/1RYe22ZPdPvAAM5unby6wJH3aYi43Ewm9/view). 
+Kosei presents their slides (https://speakerdeck.com/akakou/privacy-enhanced-revocation-and-view-of-applying-to-web). 
 
 Borbala: Apple device check allows developer 2 bits per device. Developer might set a bit that sticks. How EPID relates to this type of system? Can you tell a little bit about how that works?
 


### PR DESCRIPTION
I moved the slide from Google Drive to Speakerdeck for persistence and management reasons.
To follow the move, I updated the link in this proceeding.

new link: https://speakerdeck.com/akakou/privacy-enhanced-revocation-and-view-of-applying-to-web